### PR TITLE
Fix deprecation warning about pcl::uint64_t.

### DIFF
--- a/src/pcl.cpp
+++ b/src/pcl.cpp
@@ -7,7 +7,7 @@ namespace dr {
 
 namespace {
 	/// Conversion from ensenso timestamp to PCL timestamp.
-	pcl::uint64_t ensensoStampToPcl(double stamp) { return (stamp - 11644473600.0) * 1000000.0; }
+	std::uint64_t ensensoStampToPcl(double stamp) { return (stamp - 11644473600.0) * 1000000.0; }
 }
 
 pcl::PointCloud<pcl::PointXYZ> toPointCloud(NxLibItem const & item, std::string const & what) {


### PR DESCRIPTION
Fixes this compiler warning:
```
[ 85%] Building CXX object CMakeFiles/dr_ensenso.dir/src/pcl.cpp.o
/home/maarten/dev/fizyr/common/src/dr_ensenso/src/pcl.cpp:10:46: warning: ‘using uint64_t = uint64_t’ is deprecated: use std::uint64_t instead of pcl::uint64_t [-Wdeprecated-declarations]
   10 |  pcl::uint64_t ensensoStampToPcl(double stamp) { return (stamp - 11644473600.0) * 1000000.0; }
```