### PR TITLE
Remove unused roscpp dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master
+### Changed
+- Remove unused `roscpp` dependency.
 
 ## 1.1.0 - 2020-12-22
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ add_link_options(LINKER:--as-needed)
 
 find_package(catkin REQUIRED COMPONENTS
 	estd
-	roscpp
 )
 
 find_package(Ensenso REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -17,5 +17,4 @@
 	<depend>jsoncpp</depend>
 	<depend>fmt</depend>
 	<depend>estd</depend>
-	<depend>roscpp</depend>
 </package>


### PR DESCRIPTION
Maybe left over from way back when `dr_ensenso_node` was the same package?