### PR TITLE
Allow clearing of calibrations when the target name is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## master
+## main
+
+### Changed
+- Clear calibration on empty frame names.
 
 ## 1.2.0 - 2021-03-09
 ### Added

--- a/src/ensenso.cpp
+++ b/src/ensenso.cpp
@@ -838,9 +838,6 @@ Result<void> Ensenso::setWorkspaceCalibration(Eigen::Isometry3d const & workspac
 }
 
 Result<void> Ensenso::clearWorkspaceCalibration(bool store) {
-	// Check if the camera is calibrated.
-	if (getWorkspaceCalibrationFrame().empty()) return estd::in_place_valid;
-
 	// calling CalibrateWorkspace with no PatternPose and DefinedPose clears the workspace.
 	NxLibCommand command(cmdCalibrateWorkspace);
 

--- a/src/pcl.cpp
+++ b/src/pcl.cpp
@@ -9,12 +9,12 @@ namespace {
 }
 
 Result<void> pointCloudToBuffer(
-		NxLibItem const & item,
-		float* buf,
-		std::size_t width,
-		std::size_t height,
-		std::optional<cv::Rect> roi
-	) {
+	NxLibItem const & item,
+	float* buf,
+	std::size_t width,
+	std::size_t height,
+	std::optional<cv::Rect> roi
+) {
 	int error = 0;
 
 	// TODO: Move the item functions to util.cpp ??


### PR DESCRIPTION
I don't see any harm in clearing the calibration when it is already cleared, so I suggest to remove this check. It also fixes a possible issue where there is a calibration which has no target name. As far as I know this is allowed by our API (though I didn't test that part).