### PR TITLE
Improve camera transformations interface

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,3 @@
 # Unreleased
-- [minor][change][pub] Clear calibration on empty frame names.
-- [minor][add] Add functions to retrieve the transformations between Mono -> Stereo, Stereo -> Mono, Stereo -> Base and Base -> Stereo.
+- [change][minor][pub] Clear calibration on empty frame names.
+- [add][minor] Add functions to retrieve the transformations between Mono -> Stereo, Stereo -> Mono, Stereo -> Base and Base -> Stereo.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,3 @@
+# Unreleased
+- [minor][change][pub] Clear calibration on empty frame names.
+- [minor][add] Add functions to retrieve the transformations between Mono -> Stereo, Stereo -> Mono, Stereo -> Base and Base -> Stereo.

--- a/CHANGELOG.old.md
+++ b/CHANGELOG.old.md
@@ -5,9 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## main
 
-### Changed
-- Clear calibration on empty frame names.
-
 ## 1.2.0 - 2021-03-09
 ### Added
 - Support for CUDA.

--- a/include/dr_ensenso/ensenso.hpp
+++ b/include/dr_ensenso/ensenso.hpp
@@ -347,10 +347,12 @@ public:
 	/// Returns the camera matrix of the monocular camera (ueye).
 	Result<Eigen::Matrix3d> getMonocularMatrix() const;
 
-	/// Returns the calibration between ueye and ensenso (specifically, the pose of the stereo camera in the monocular frame).
+	/// Returns the calibration link between the monocular camera (ueye) and the stereo camera (ensenso).
+	//  NOTE: the link represents the pose of the stereo camera in the monocular frame.
 	Result<Eigen::Isometry3d> getMonocularLink() const;
 
-	/// Returns the calibration between ensenso and the base frame (specifically, the pose of the base frame in the stereo frame).
+	/// Returns the calibration link between the stereo camera (ensenso) and the base frame.
+	//  NOTE: the link represents the pose of the base in the stereo frame.
 	Result<Eigen::Isometry3d> getStereoLink() const;
 
 	/// Returns the pose of the monocular camera in the stereo frame.

--- a/include/dr_ensenso/ensenso.hpp
+++ b/include/dr_ensenso/ensenso.hpp
@@ -344,14 +344,26 @@ public:
 		std::string * result_dump_info = nullptr                     ///< If provided, copies the result to this string as json.
 	);
 
-	/// Returns the camera matrix of the ueye.
+	/// Returns the camera matrix of the monocular camera (ueye).
 	Result<Eigen::Matrix3d> getMonocularMatrix() const;
 
-	/// Returns the calibration between ueye and ensenso.
+	/// Returns the calibration between ueye and ensenso (specifically, the pose of the stereo camera in the monocular frame).
 	Result<Eigen::Isometry3d> getMonocularLink() const;
 
-	/// Returns the calibration between ensenso and the base frame.
+	/// Returns the calibration between ensenso and the base frame (specifically, the pose of the base frame in the stereo frame).
 	Result<Eigen::Isometry3d> getStereoLink() const;
+
+	/// Returns the pose of the monocular camera in the stereo frame.
+	Result<Eigen::Isometry3d> getMonoToStereo() const;
+
+	/// Returns the pose of the stereo camera in the base frame.
+	Result<Eigen::Isometry3d> getStereoToBase() const;
+
+	/// Returns the pose of the stereo camera in the monocular frame.
+	Result<Eigen::Isometry3d> getStereoToMono() const;
+
+	/// Returns the pose of the base in the stereo frame.
+	Result<Eigen::Isometry3d> getBaseToStereo() const;
 
 	/// Gets capture parameters.
 	Result<CaptureParams> getCaptureParameters(bool crop_to_roi = false);

--- a/src/ensenso.cpp
+++ b/src/ensenso.cpp
@@ -890,23 +890,45 @@ Result<Eigen::Matrix3d> Ensenso::getMonocularMatrix() const {
 }
 
 Result<Eigen::Isometry3d> Ensenso::getMonocularLink() const {
-	// convert from mm to m
+	// NOTE: Ensenso returns the pose of the stereo camera in the monocular frame.
 	Result<Eigen::Isometry3d> pose = toEigenIsometry(monocular_node.value()[itmLink]);
 	if (!pose) return pose.error().push_description("failed to get monocular link pose");
 
+	// Convert from mm to m.
 	pose->translation() *= 0.001;
 
 	return pose;
 }
 
 Result<Eigen::Isometry3d> Ensenso::getStereoLink() const {
-	// convert from mm to m
+	// NOTE: Ensenso returns the pose of the base frame in the stereo frame.
 	Result<Eigen::Isometry3d> pose = toEigenIsometry(stereo_node[itmLink]);
 	if (!pose) return pose.error().push_description("failed to get stereo link pose");
 
+	// Convert from mm to m.
 	pose->translation() *= 0.001;
 
 	return pose;
+}
+
+Result<Eigen::Isometry3d> Ensenso::getMonoToStereo() const {
+	Result<Eigen::Isometry3d> stereo_to_mono = getMonocularLink();
+	if (!stereo_to_mono) return stereo_to_mono.error();
+	return stereo_to_mono->inverse();
+}
+
+Result<Eigen::Isometry3d> Ensenso::getStereoToBase() const {
+	Result<Eigen::Isometry3d> base_to_stereo = getStereoLink();
+	if (!base_to_stereo) return base_to_stereo.error();
+	return base_to_stereo->inverse();
+}
+
+Result<Eigen::Isometry3d> Ensenso::getStereoToMono() const {
+	return getMonocularLink();
+}
+
+Result<Eigen::Isometry3d> Ensenso::getBaseToStereo() const {
+	return getStereoLink();
 }
 
 Result<Ensenso::CaptureParams> Ensenso::getCaptureParameters(bool crop_to_roi) {


### PR DESCRIPTION
Add functions to retrieve the transformations between Mono -> Stereo, Stereo -> Mono, Stereo -> Base and Base -> Stereo. Adapt to the new CHANGELOG style.