### PR TITLE
OpenCV VTK fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# Unreleased
+- [fix][patch] Add target for VTK::jsoncpp to work around OpenCV issue.
+
 # Version 1.5.0 - 2023-06-19
 - [add][minor] Add functionality to save debug nxlog files for ensenso cameras.
 - [add][minor] Add functionality to dump ensenso camera tree.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ find_package(catkin REQUIRED COMPONENTS
 find_package(Ensenso REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem date_time chrono)
 find_package(Eigen3 REQUIRED)
+# This VTK component is required by OpenCV, they should search for this target..
+# Some more information: https://gitlab.kitware.com/cmake/cmake/-/issues/24210
+find_package(VTK REQUIRED COMPONENTS jsoncpp)
 find_package(OpenCV REQUIRED)
 find_package(jsoncpp REQUIRED)
 find_package(fmt REQUIRED)


### PR DESCRIPTION
This fixes the following issue while compiling:

```
CMake Error at /usr/lib/cmake/vtk/VTK-targets.cmake:482 (set_target_properties):
  The link interface of target "VTK::jsoncpp" contains:

    JsonCpp::JsonCpp

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  /usr/lib/cmake/vtk/vtk-config.cmake:145 (include)
  /usr/share/pcl-1.14/PCLConfig.cmake:271 (find_package)
  /usr/share/pcl-1.14/PCLConfig.cmake:320 (find_VTK)
  /usr/share/pcl-1.14/PCLConfig.cmake:561 (find_external_library)
  CMakeLists.txt:23 (find_package)
```